### PR TITLE
Fix: Invalid response received from server

### DIFF
--- a/bin/bloonix-update-agent-host-config.in
+++ b/bin/bloonix-update-agent-host-config.in
@@ -299,7 +299,7 @@ sub update_hosts {
 
         print $fh join("",
             "host {\n",
-            "    host_id  $host->{id}.$agent_id\n",
+            "    host_id  $host->{id}\n",
             "    password $host->{password}\n",
             "    agent_id $self->{agent_id}\n",
             "}\n",


### PR DESCRIPTION
The variable agent_id is already defined, so we do not need this dot notation inside host_id parameter. Further
the upstream server (bloonix-webgui) can not interpret this dot notation and will raise an error.