### PR TITLE
Add more \n to send_mails to fix gmail issue

### DIFF
--- a/perl/lib/Bloonix/Server.pm
+++ b/perl/lib/Bloonix/Server.pm
@@ -2509,7 +2509,7 @@ sub send_mails {
         my (%status, $status, $redirect, @id);
 
         my $message = "*** Status for host $host->{hostname} ($host->{ipaddr}) at ". $self->stime ." ***\n\n";
-        $message .= "https://$hostname/#monitoring/hosts/$host->{id}\n";
+        $message .= "\nhttps://$hostname/#monitoring/hosts/$host->{id}\n\n";
 
         $subject =~ s/%a/$host->{ipaddr}/;
         $subject =~ s/%h/$host->{hostname}/;


### PR DESCRIPTION
Added more \n between lines in order to make gmail not (wrongfully, imho) join description line onto generated clickable link.